### PR TITLE
Fixed the ugly borders when using the default theme in elementary OS Freya

### DIFF
--- a/meocloud_gui/gui/setupwindow.py
+++ b/meocloud_gui/gui/setupwindow.py
@@ -1,6 +1,6 @@
 import os
 import socket
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from meocloud_gui.gui.pages import Pages
 from meocloud_gui.gui.prefswindow import PrefsWindow
 from meocloud_gui.gui.spinnerbox import SpinnerBox
@@ -24,6 +24,23 @@ class SetupWindow(Gtk.Window):
 
         self.app = app
         self.pages = Pages()
+        self.pages.set_name("WelcomePages")
+
+        style_provider = Gtk.CssProvider()
+
+        css = """
+        #WelcomePages {
+            border: 0;
+        }
+        """
+
+        style_provider.load_from_data(css)
+
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(), 
+            style_provider,     
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
 
         try:
             if not app.use_headerbar:


### PR DESCRIPTION
What the title says. This has been annoying me for a while, so here is a simple fix.

Before:
![before](https://cloud.githubusercontent.com/assets/3475499/5962530/8e64aec6-a7dc-11e4-8330-2e3025e91c8a.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/3475499/5962531/8fcaca0c-a7dc-11e4-9a3e-317707750518.jpg)
