### PR TITLE
Update dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 keyring
 thrift==0.9.1
+pygobject3 
+python3-gobject


### PR DESCRIPTION
Fixes dependency in rpm (Fedora)
Error: "GTK is required, please install gtk+ 3 with the GIR bindings"